### PR TITLE
chore: flutter_svg version

### DIFF
--- a/packages/ui_components_lib/pubspec.yaml
+++ b/packages/ui_components_lib/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   another_flushbar: ^1.12.29
   flutter:
     sdk: flutter
-  flutter_svg: ^2.0.4
+  flutter_svg: ^2.0.5
   flutter_typeahead: ^4.3.7
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -491,10 +491,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "017cb37b3e9bee44cc800e35469f295d537484602f02ce6ceb5876236cc7e1fe"
+      sha256: f991fdb1533c3caeee0cdc14b04f50f0c3916f0dbcbc05237ccbe4e3c6b93f3f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter_bloc: ^8.1.1
   flutter_localizations:
     sdk: flutter
-  flutter_svg: 2.0.3
+  flutter_svg: ^2.0.5
   freezed_annotation: ^2.2.0
   get_it: ^7.2.0
   go_router: ^7.0.0


### PR DESCRIPTION
## Description

Because every version of ui_components_lib from path depends on flutter_svg ^2.0.4 and app depends on flutter_svg 2.0.3, ui_components_lib from path is forbidden.
So, because app depends on ui_components_lib from path, version solving failed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
