### PR TITLE
fix: deploy storybook only when pushing to main

### DIFF
--- a/.github/workflows/storybook-gh-pages-deploy.yaml
+++ b/.github/workflows/storybook-gh-pages-deploy.yaml
@@ -3,9 +3,8 @@ name: Deploy storybook to GitHub Pages
 
 on:
   push:
-    paths:
-      - 'packages/ui_components_lib/lib/**'
-      - 'packages/ui_components_lib/assets/**'
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
## Description

I don't understand why dependabot triggers the deploy workflow despite triggers was based on paths, but fuck it, lets deploy only from main automatically. You **ALWAYS** can trigger it from **ANY** branch manually.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
