### PR TITLE
feat: implement manage seeds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
         run: melos codegen --no-select
 
       - name: Run Flutter integration tests
-        uses: Wandalen/wretry.action@master # sometimes android tests are flaky
+        uses: Wandalen/wretry.action@v1.0.36 # sometimes android tests are flaky
         with:
           attempt_limit: 5
           action: reactivecircus/android-emulator-runner@v2

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -26,8 +26,8 @@
   "skipTakeRisk": "Skip, I'll take the risk",
   "copiedExclamation": "Copied!",
   "copyWords": "Copy all words",
-  "seedPhraseNameTitle": "Enter the name for seed phrase",
-  "seedPhraseNameDescription": "It is not necessary, but it will help identify this particular seed if you have a lot of them.",
+  "enterSeedNameScreenTitle": "Enter new name for seed phrase",
+  "enterSeedNameScreenDescription": "It is not necessary, but it will help you to identify this particular seed if you have a lot of them.",
   "seedName": "Seed name",
   "continueWord": "Continue",
   "confirm": "Confirm",
@@ -52,5 +52,21 @@
   "languageWord": "Language",
   "biometryWord": "Biometry",
   "darkTheme": "DarkTheme",
-  "logOut": "Log out"
+  "logOut": "Log out",
+  "totalBalance": "Total balance",
+  "seedPhrases": "Seed phrases",
+  "addSeedPhrase": "Add seed phrase",
+  "addNewSeedPhrase": "Add new seed phrase",
+  "publicKeysWithData": {
+    "one": "{} public key • {data}",
+    "other": "{} public keys • {data}"
+  },
+  "createNewSeed": "Create new seed",
+  "importSeed": "Import seed",
+  "settingsOfSeed": "Settings of the seed phrase",
+  "useThisSeed": "Use this seed",
+  "renameWord": "Rename",
+  "exportWord": "Export",
+  "changePassword": "Change password",
+  "deleteWord": "Delete"
 }

--- a/lib/app/router/app_route.dart
+++ b/lib/app/router/app_route.dart
@@ -6,10 +6,17 @@ enum AppRoute {
   onboarding('onboarding', '/onboarding', isSaveLocation: true),
   wallet('wallet', '/wallet', isSaveLocation: true),
   browser('browser', '/browser', isSaveLocation: true),
+
+  /// Profile section
   profile('profile', '/profile', isSaveLocation: true),
+  manageSeedsAccounts('manageSeeds', 'manageSeeds', isSaveLocation: true),
+
+  /// Adding seed (name is optional)
   createSeed('', 'createSeed', isSaveLocation: true),
-  checkSeed('', 'checkSeed'),
   enterSeed('', 'enterSeed', isSaveLocation: true),
+  // command flag means: 'import' - import, 'create' (or other) - create
+  enterSeedName('', 'enterSeedName/:command', isSaveLocation: true),
+  checkSeed('', 'checkSeed'),
   createSeedPassword('', 'createSeedPassword');
 
   const AppRoute(this.name, this.path, {this.isSaveLocation = false});
@@ -31,6 +38,26 @@ enum AppRoute {
   }
 
   static AppRoute get defaultRoute => onboarding;
+
+  /// Helper method, that allows add path parameter to [path].
+  ///
+  /// If [path] field of [AppRoute] contains [':'] then [data] will replace this
+  /// parameter.
+  // TODO(alex-a4): we need check if this will work in a nested routes with data
+  //   I mean, if routes above this will contains :data in their path or it was
+  //   replace by them when they were pushed.
+  String pathWithData(String data) {
+    if (path.contains(':')) {
+      return path.replaceAll(RegExp(r':\w*'), data);
+    }
+
+    return path;
+  }
+
+  /// Helper method, that allows add query parameters to [path].
+  String pathWithQuery(Map<String, String>? query) {
+    return Uri(path: path, queryParameters: query).toString();
+  }
 }
 
 /// Get first segment from [location].
@@ -73,8 +100,28 @@ extension NavigationHelper on BuildContext {
   /// onPressed: () => context.goFurther(AppRoute.multiuse.path),
   /// ```
   void goFurther(String location, {Object? extra}) {
-    return GoRouter.of(this)
-        .go('${GoRouter.of(this).location}/$location', extra: extra);
+    var resultLocation = Uri.parse(GoRouter.of(this).location);
+    // We have query params in old path and we must update it manually
+    if (resultLocation.hasQuery) {
+      final newLocation = Uri.parse(location);
+      final query = <String, dynamic>{}
+        ..addAll(resultLocation.queryParameters)
+        ..addAll(newLocation.queryParameters);
+
+      resultLocation = resultLocation.replace(
+        path: '${resultLocation.path}/${newLocation.path}',
+        queryParameters: query,
+      );
+    } else {
+      // old location do not have query, new one may have it, we dont care
+      resultLocation =
+          resultLocation.replace(path: '${resultLocation.path}/$location');
+    }
+
+    return GoRouter.of(this).go(
+      Uri.decodeComponent(resultLocation.toString()),
+      extra: extra,
+    );
   }
 
   /// Pop current screen if possible.

--- a/lib/app/router/app_route.dart
+++ b/lib/app/router/app_route.dart
@@ -1,3 +1,4 @@
+import 'package:app/feature/add_seed/enter_seed_name/enter_seed_name.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
@@ -11,11 +12,19 @@ enum AppRoute {
   profile('profile', '/profile', isSaveLocation: true),
   manageSeedsAccounts('manageSeeds', 'manageSeeds', isSaveLocation: true),
 
-  /// Adding seed (name is optional)
+  /// Adding seed
   createSeed('', 'createSeed', isSaveLocation: true),
+  createSeedNamed('', 'createSeed/:$enterSeedNameName', isSaveLocation: true),
   enterSeed('', 'enterSeed', isSaveLocation: true),
-  // command flag means: 'import' - import, 'create' (or other) - create
-  enterSeedName('', 'enterSeedName/:command', isSaveLocation: true),
+  enterSeedNamed('', 'enterSeed/:name', isSaveLocation: true),
+
+  // command flag means: 'import' - import, 'create' (or other) - create,
+  // see <enterSeedNameImportCommand> and <enterSeedNameCreateCommand>.
+  enterSeedName(
+    '',
+    'enterSeedName/:$enterSeedNameCommand',
+    isSaveLocation: true,
+  ),
   checkSeed('', 'checkSeed'),
   createSeedPassword('', 'createSeedPassword');
 

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -5,10 +5,12 @@ import 'package:app/di/di.dart';
 import 'package:app/feature/add_seed/check_seed_phrase/check_seed_phrase.dart';
 import 'package:app/feature/add_seed/create_password/create_password.dart';
 import 'package:app/feature/add_seed/create_seed/create_seed.dart';
+import 'package:app/feature/add_seed/enter_seed_name/enter_seed_name.dart';
 import 'package:app/feature/add_seed/enter_seed_phrase/enter_seed_phrase.dart';
 import 'package:app/feature/browser/browser.dart';
 import 'package:app/feature/error/error.dart';
 import 'package:app/feature/onboarding/onboarding.dart';
+import 'package:app/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart';
 import 'package:app/feature/profile/profile.dart';
 import 'package:app/feature/root/root.dart';
 import 'package:app/feature/wallet/wallet.dart';
@@ -83,7 +85,7 @@ GoRouter getRouter(BuildContext _) {
               ),
               GoRoute(
                 path: AppRoute.createSeedPassword.path,
-                builder: (BuildContext context, GoRouterState state) =>
+                builder: (_, GoRouterState state) =>
                     CreateSeedPasswordOnboardingPage(
                   extra: state.extra! as CreateSeedRouteExtra,
                 ),
@@ -96,7 +98,7 @@ GoRouter getRouter(BuildContext _) {
             routes: [
               GoRoute(
                 path: AppRoute.createSeedPassword.path,
-                builder: (BuildContext context, GoRouterState state) =>
+                builder: (_, GoRouterState state) =>
                     CreateSeedPasswordOnboardingPage(
                   extra: state.extra! as CreateSeedRouteExtra,
                 ),
@@ -141,6 +143,69 @@ GoRouter getRouter(BuildContext _) {
               state,
               const ProfilePage(),
             ),
+            routes: [
+              GoRoute(
+                path: AppRoute.manageSeedsAccounts.path,
+                name: AppRoute.manageSeedsAccounts.name,
+                builder: (_, __) => const ManageSeedsAccountsPage(),
+                routes: [
+                  GoRoute(
+                    path: AppRoute.enterSeedName.path,
+                    builder: (_, state) => EnterSeedNamePage(
+                      command: state.pathParameters['command'] ??
+                          enterSeedNameImportCommand,
+                    ),
+                    routes: [
+                      GoRoute(
+                        path: AppRoute.createSeed.path,
+                        builder: (_, state) => CreateSeedPage(
+                          name: state.queryParameters['name'],
+                        ),
+                        routes: [
+                          GoRoute(
+                            path: AppRoute.checkSeed.path,
+                            builder: (_, state) => CheckSeedPhrasePage(
+                              extra: state.extra! as CreateSeedRouteExtra,
+                            ),
+                            routes: [
+                              GoRoute(
+                                path: AppRoute.createSeedPassword.path,
+                                builder: (_, state) =>
+                                    CreateSeedPasswordProfilePage(
+                                  extra: state.extra! as CreateSeedRouteExtra,
+                                ),
+                              ),
+                            ],
+                          ),
+                          GoRoute(
+                            path: AppRoute.createSeedPassword.path,
+                            builder: (_, GoRouterState state) =>
+                                CreateSeedPasswordProfilePage(
+                              extra: state.extra! as CreateSeedRouteExtra,
+                            ),
+                          ),
+                        ],
+                      ),
+                      GoRoute(
+                        path: AppRoute.enterSeed.path,
+                        builder: (_, state) => EnterSeedPhrasePage(
+                          name: state.queryParameters['name'],
+                        ),
+                        routes: [
+                          GoRoute(
+                            path: AppRoute.createSeedPassword.path,
+                            builder: (_, GoRouterState state) =>
+                                CreateSeedPasswordProfilePage(
+                              extra: state.extra! as CreateSeedRouteExtra,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -2,23 +2,15 @@ import 'package:app/app/router/page_transitions.dart';
 import 'package:app/app/router/router.dart';
 import 'package:app/app/service/service.dart';
 import 'package:app/di/di.dart';
-import 'package:app/feature/add_seed/check_seed_phrase/check_seed_phrase.dart';
-import 'package:app/feature/add_seed/create_password/create_password.dart';
-import 'package:app/feature/add_seed/create_seed/create_seed.dart';
-import 'package:app/feature/add_seed/enter_seed_name/enter_seed_name.dart';
-import 'package:app/feature/add_seed/enter_seed_phrase/enter_seed_phrase.dart';
-import 'package:app/feature/browser/browser.dart';
 import 'package:app/feature/error/error.dart';
 import 'package:app/feature/onboarding/onboarding.dart';
-import 'package:app/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart';
-import 'package:app/feature/profile/profile.dart';
 import 'package:app/feature/root/root.dart';
-import 'package:app/feature/wallet/wallet.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nekoton_repository/nekoton_repository.dart';
 
 export 'app_route.dart';
+export 'routs/routs.dart';
 
 // ignore: long-method
 GoRouter getRouter(BuildContext _) {
@@ -65,46 +57,8 @@ GoRouter getRouter(BuildContext _) {
           const OnboardingPage(),
         ),
         routes: [
-          GoRoute(
-            path: AppRoute.createSeed.path,
-            builder: (_, __) => const CreateSeedPage(),
-            routes: [
-              GoRoute(
-                path: AppRoute.checkSeed.path,
-                builder: (_, state) => CheckSeedPhrasePage(
-                  extra: state.extra! as CreateSeedRouteExtra,
-                ),
-                routes: [
-                  GoRoute(
-                    path: AppRoute.createSeedPassword.path,
-                    builder: (_, state) => CreateSeedPasswordOnboardingPage(
-                      extra: state.extra! as CreateSeedRouteExtra,
-                    ),
-                  ),
-                ],
-              ),
-              GoRoute(
-                path: AppRoute.createSeedPassword.path,
-                builder: (_, GoRouterState state) =>
-                    CreateSeedPasswordOnboardingPage(
-                  extra: state.extra! as CreateSeedRouteExtra,
-                ),
-              ),
-            ],
-          ),
-          GoRoute(
-            path: AppRoute.enterSeed.path,
-            builder: (_, __) => const EnterSeedPhrasePage(),
-            routes: [
-              GoRoute(
-                path: AppRoute.createSeedPassword.path,
-                builder: (_, GoRouterState state) =>
-                    CreateSeedPasswordOnboardingPage(
-                  extra: state.extra! as CreateSeedRouteExtra,
-                ),
-              ),
-            ],
-          ),
+          createSeedNoNamedOnboardingRoute,
+          enterSeedNoNamedOnboardingRoute,
         ],
       ),
       ShellRoute(
@@ -114,99 +68,9 @@ GoRouter getRouter(BuildContext _) {
           RootPage(child: child),
         ),
         routes: <RouteBase>[
-          GoRoute(
-            name: AppRoute.wallet.name,
-            path: AppRoute.wallet.path,
-            pageBuilder: (BuildContext context, GoRouterState state) =>
-                rootTabsTransitionPageBuilder(
-              context,
-              state,
-              const WalletPage(),
-            ),
-          ),
-          GoRoute(
-            name: AppRoute.browser.name,
-            path: AppRoute.browser.path,
-            pageBuilder: (BuildContext context, GoRouterState state) =>
-                rootTabsTransitionPageBuilder(
-              context,
-              state,
-              const BrowserPage(),
-            ),
-          ),
-          GoRoute(
-            name: AppRoute.profile.name,
-            path: AppRoute.profile.path,
-            pageBuilder: (BuildContext context, GoRouterState state) =>
-                rootTabsTransitionPageBuilder(
-              context,
-              state,
-              const ProfilePage(),
-            ),
-            routes: [
-              GoRoute(
-                path: AppRoute.manageSeedsAccounts.path,
-                name: AppRoute.manageSeedsAccounts.name,
-                builder: (_, __) => const ManageSeedsAccountsPage(),
-                routes: [
-                  GoRoute(
-                    path: AppRoute.enterSeedName.path,
-                    builder: (_, state) => EnterSeedNamePage(
-                      command: state.pathParameters['command'] ??
-                          enterSeedNameImportCommand,
-                    ),
-                    routes: [
-                      GoRoute(
-                        path: AppRoute.createSeed.path,
-                        builder: (_, state) => CreateSeedPage(
-                          name: state.queryParameters['name'],
-                        ),
-                        routes: [
-                          GoRoute(
-                            path: AppRoute.checkSeed.path,
-                            builder: (_, state) => CheckSeedPhrasePage(
-                              extra: state.extra! as CreateSeedRouteExtra,
-                            ),
-                            routes: [
-                              GoRoute(
-                                path: AppRoute.createSeedPassword.path,
-                                builder: (_, state) =>
-                                    CreateSeedPasswordProfilePage(
-                                  extra: state.extra! as CreateSeedRouteExtra,
-                                ),
-                              ),
-                            ],
-                          ),
-                          GoRoute(
-                            path: AppRoute.createSeedPassword.path,
-                            builder: (_, GoRouterState state) =>
-                                CreateSeedPasswordProfilePage(
-                              extra: state.extra! as CreateSeedRouteExtra,
-                            ),
-                          ),
-                        ],
-                      ),
-                      GoRoute(
-                        path: AppRoute.enterSeed.path,
-                        builder: (_, state) => EnterSeedPhrasePage(
-                          name: state.queryParameters['name'],
-                        ),
-                        routes: [
-                          GoRoute(
-                            path: AppRoute.createSeedPassword.path,
-                            builder: (_, GoRouterState state) =>
-                                CreateSeedPasswordProfilePage(
-                              extra: state.extra! as CreateSeedRouteExtra,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ),
+          walletRoute,
+          browserRoute,
+          profileRoute,
         ],
       ),
     ],

--- a/lib/app/router/routs/add_seed/add_seed.dart
+++ b/lib/app/router/routs/add_seed/add_seed.dart
@@ -1,0 +1,155 @@
+import 'package:app/app/router/router.dart';
+import 'package:app/feature/add_seed/check_seed_phrase/check_seed_phrase.dart';
+import 'package:app/feature/add_seed/create_password/create_password.dart';
+import 'package:app/feature/add_seed/create_seed/create_seed.dart';
+import 'package:app/feature/add_seed/enter_seed_name/enter_seed_name.dart';
+import 'package:app/feature/add_seed/enter_seed_phrase/enter_seed_phrase.dart';
+import 'package:go_router/go_router.dart';
+
+/// Route that allows to create a seed phrase without entering name.
+/// This route may be used in onboarding or profile section, depends
+/// on [passwordRoute].
+GoRoute createSeedNoNamedRoute(GoRoute passwordRoute) {
+  return GoRoute(
+    path: AppRoute.createSeed.path,
+    builder: (_, __) => const CreateSeedPage(),
+    routes: [
+      GoRoute(
+        path: AppRoute.checkSeed.path,
+        builder: (_, state) => CheckSeedPhrasePage(
+          extra: state.extra! as CreateSeedRouteExtra,
+        ),
+        routes: [
+          passwordRoute,
+        ],
+      ),
+      passwordRoute,
+    ],
+  );
+}
+
+/// Route that allows to enter a seed phrase without entering name.
+/// This route may be used in onboarding or profile section, depends
+/// on [passwordRoute].
+GoRoute enterSeedNoNamedRoute(GoRoute passwordRoute) {
+  return GoRoute(
+    path: AppRoute.enterSeed.path,
+    builder: (_, __) => const EnterSeedPhrasePage(),
+    routes: [
+      passwordRoute,
+    ],
+  );
+}
+
+/// Route that allows to create a seed phrase in onboarding without name.
+GoRoute get createSeedNoNamedOnboardingRoute {
+  return createSeedNoNamedRoute(
+    GoRoute(
+      path: AppRoute.createSeedPassword.path,
+      builder: (_, state) => CreateSeedPasswordOnboardingPage(
+        extra: state.extra! as CreateSeedRouteExtra,
+      ),
+    ),
+  );
+}
+
+/// Route that allows to enter a seed phrase in onboarding without name.
+GoRoute get enterSeedNoNamedOnboardingRoute {
+  return enterSeedNoNamedRoute(
+    GoRoute(
+      path: AppRoute.createSeedPassword.path,
+      builder: (_, GoRouterState state) => CreateSeedPasswordOnboardingPage(
+        extra: state.extra! as CreateSeedRouteExtra,
+      ),
+    ),
+  );
+}
+
+/// Route that allows to create a seed phrase in profile without name.
+GoRoute get createSeedNoNamedProfileRoute {
+  return createSeedNoNamedRoute(
+    GoRoute(
+      path: AppRoute.createSeedPassword.path,
+      builder: (_, state) => CreateSeedPasswordProfilePage(
+        extra: state.extra! as CreateSeedRouteExtra,
+      ),
+    ),
+  );
+}
+
+/// Route that allows to enter a seed phrase in profile without name.
+GoRoute get enterSeedNoNamedProfileRoute {
+  return enterSeedNoNamedRoute(
+    GoRoute(
+      path: AppRoute.createSeedPassword.path,
+      builder: (_, GoRouterState state) => CreateSeedPasswordProfilePage(
+        extra: state.extra! as CreateSeedRouteExtra,
+      ),
+    ),
+  );
+}
+
+/// Route that allows to create a seed phrase with entering name.
+/// Typically used in profile.
+GoRoute get createSeedNamedProfileRoute {
+  final passwordRoute = GoRoute(
+    path: AppRoute.createSeedPassword.path,
+    builder: (_, GoRouterState state) => CreateSeedPasswordProfilePage(
+      extra: state.extra! as CreateSeedRouteExtra,
+    ),
+  );
+
+  return GoRoute(
+    path: AppRoute.createSeedNamed.path,
+    builder: (_, state) => CreateSeedPage(
+      name: state.pathParameters[enterSeedNameName],
+    ),
+    routes: [
+      GoRoute(
+        path: AppRoute.checkSeed.path,
+        builder: (_, state) => CheckSeedPhrasePage(
+          extra: state.extra! as CreateSeedRouteExtra,
+        ),
+        routes: [
+          passwordRoute,
+        ],
+      ),
+      passwordRoute,
+    ],
+  );
+}
+
+/// Route that allows to enter a seed phrase with entering name.
+/// Typically used in profile.
+GoRoute get enterSeedNamedProfileRoute {
+  return GoRoute(
+    path: AppRoute.enterSeedNamed.path,
+    builder: (_, state) => EnterSeedPhrasePage(
+      name: state.pathParameters[enterSeedNameName],
+    ),
+    routes: [
+      GoRoute(
+        path: AppRoute.createSeedPassword.path,
+        builder: (_, GoRouterState state) => CreateSeedPasswordProfilePage(
+          extra: state.extra! as CreateSeedRouteExtra,
+        ),
+      ),
+    ],
+  );
+}
+
+/// Route that allows CRATE or ENTER seed phrase with entering name.
+GoRoute get addSeedNamedRoute {
+  return GoRoute(
+    path: AppRoute.enterSeedName.path,
+    builder: (_, state) => EnterSeedNamePage(
+      commandName: state.pathParameters[enterSeedNameCommand],
+    ),
+    routes: [
+      createSeedNoNamedProfileRoute,
+      createSeedNamedProfileRoute,
+      enterSeedNoNamedProfileRoute,
+      enterSeedNamedProfileRoute,
+    ],
+  );
+}

--- a/lib/app/router/routs/browser/browser.dart
+++ b/lib/app/router/routs/browser/browser.dart
@@ -1,0 +1,19 @@
+import 'package:app/app/router/page_transitions.dart';
+import 'package:app/app/router/router.dart';
+import 'package:app/feature/browser/browser.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Route that is root for browser.
+GoRoute get browserRoute {
+  return GoRoute(
+    name: AppRoute.browser.name,
+    path: AppRoute.browser.path,
+    pageBuilder: (BuildContext context, GoRouterState state) =>
+        rootTabsTransitionPageBuilder(
+      context,
+      state,
+      const BrowserPage(),
+    ),
+  );
+}

--- a/lib/app/router/routs/profile/profile.dart
+++ b/lib/app/router/routs/profile/profile.dart
@@ -1,0 +1,35 @@
+import 'package:app/app/router/page_transitions.dart';
+import 'package:app/app/router/router.dart';
+import 'package:app/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart';
+import 'package:app/feature/profile/profile.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Get route for profile root.
+GoRoute get profileRoute {
+  return GoRoute(
+    name: AppRoute.profile.name,
+    path: AppRoute.profile.path,
+    pageBuilder: (BuildContext context, GoRouterState state) =>
+        rootTabsTransitionPageBuilder(
+      context,
+      state,
+      const ProfilePage(),
+    ),
+    routes: [
+      manageSeedAccountsRoute,
+    ],
+  );
+}
+
+/// Get route for manage seed accounts.
+GoRoute get manageSeedAccountsRoute {
+  return GoRoute(
+    path: AppRoute.manageSeedsAccounts.path,
+    name: AppRoute.manageSeedsAccounts.name,
+    builder: (_, __) => const ManageSeedsAccountsPage(),
+    routes: [
+      addSeedNamedRoute,
+    ],
+  );
+}

--- a/lib/app/router/routs/routs.dart
+++ b/lib/app/router/routs/routs.dart
@@ -1,0 +1,4 @@
+export 'add_seed/add_seed.dart';
+export 'browser/browser.dart';
+export 'profile/profile.dart';
+export 'wallet/wallet.dart';

--- a/lib/app/router/routs/wallet/wallet.dart
+++ b/lib/app/router/routs/wallet/wallet.dart
@@ -1,0 +1,19 @@
+import 'package:app/app/router/page_transitions.dart';
+import 'package:app/app/router/router.dart';
+import 'package:app/feature/wallet/wallet.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Route that is root for wallet.
+GoRoute get walletRoute {
+  return GoRoute(
+    name: AppRoute.wallet.name,
+    path: AppRoute.wallet.path,
+    pageBuilder: (BuildContext context, GoRouterState state) =>
+        rootTabsTransitionPageBuilder(
+      context,
+      state,
+      const WalletPage(),
+    ),
+  );
+}

--- a/lib/app/service/currency_convert_service.dart
+++ b/lib/app/service/currency_convert_service.dart
@@ -1,0 +1,29 @@
+import 'package:injectable/injectable.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+
+const _usdScale = 2;
+
+/// This is a service that helps converting some real-world currency to another.
+///
+/// !!! We do not know now how it will look like, but this is an attempt to
+/// predict some common behavior.
+@singleton
+class CurrencyConvertService {
+  CurrencyConvertService() {
+    Currencies().register(
+      Currency.create(
+        'USD',
+        _usdScale,
+        name: 'USD',
+      ),
+    );
+  }
+
+  /// Convert [amount] in USD currency to [currency] (aka USD, euro, won etc).
+  ///
+  /// !!! Now this is just a direct returning of amount with USD currency.
+  // ignore: avoid-unused-parameters
+  Future<Money> convert(Fixed amount, {Currency? currency}) async {
+    return Money.fromFixed(amount, code: 'USD');
+  }
+}

--- a/lib/app/service/currency_convert_service.dart
+++ b/lib/app/service/currency_convert_service.dart
@@ -1,8 +1,6 @@
 import 'package:injectable/injectable.dart';
 import 'package:nekoton_repository/nekoton_repository.dart';
 
-const _usdScale = 2;
-
 /// This is a service that helps converting some real-world currency to another.
 ///
 /// !!! We do not know now how it will look like, but this is an attempt to
@@ -11,11 +9,7 @@ const _usdScale = 2;
 class CurrencyConvertService {
   CurrencyConvertService() {
     Currencies().register(
-      Currency.create(
-        'USD',
-        _usdScale,
-        name: 'USD',
-      ),
+      CommonCurrencies().usd,
     );
   }
 

--- a/lib/app/service/current_seed_service.dart
+++ b/lib/app/service/current_seed_service.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:app/app/service/service.dart';
+import 'package:injectable/injectable.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// This is a support service for profile section that allows getting and
+/// listening for current seed based on seed list and current key.
+///
+/// This service supports auto-updating of current key if seed is changed.
+@singleton
+class CurrentSeedService {
+  CurrentSeedService(this.nekotonRepository, this.currentKeyService);
+
+  final NekotonRepository nekotonRepository;
+  final CurrentKeyService currentKeyService;
+
+  /// Subject of current seed
+  final _currentSeedSubject = BehaviorSubject<Seed?>();
+
+  /// Subscriptions
+  late StreamSubscription<SeedList> _seedSubscription;
+  late StreamSubscription<String?> _currentKeySubscription;
+
+  /// Stream of current seed.
+  /// If stream do not contains any seed, this means that there are no seeds
+  /// in app and it is logged out.
+  Stream<Seed?> get currentSeedStream => _currentSeedSubject;
+
+  /// If seed is null, this means that there are no seeds in app and it is
+  /// logged out.
+  Seed? get currentSeed => _currentSeedSubject.valueOrNull;
+
+  /// Initialization of this service must be called only after initializing of
+  /// [NekotonRepository] and [CurrentKeyService] which initialized by storage.
+  Future<void> init() {
+    // skip 1 to avoid duplicate init
+    _currentKeySubscription = currentKeyService.currentKeyStream
+        .skip(1)
+        .listen((current) => _updateData(current, nekotonRepository.seedList));
+    _seedSubscription = nekotonRepository.seedListStream
+        .skip(1)
+        .listen((list) => _updateData(currentKeyService.currentKey, list));
+
+    return _updateData(
+      currentKeyService.currentKey,
+      nekotonRepository.seedList,
+    );
+  }
+
+  /// Closes all subscriptions and streams.
+  void dispose() {
+    _seedSubscription.cancel();
+    _currentKeySubscription.cancel();
+    _currentSeedSubject.close();
+  }
+
+  Future<void> _updateData(
+    String? currentKey,
+    SeedList list,
+  ) async {
+    final seed = await _tryUpdateCurrentKey(currentKey, list);
+    if (seed != null) {
+      _currentSeedSubject.add(seed);
+    }
+  }
+
+  /// Checks that [currentKey] has seed instance or try update currentKey in
+  /// storage.
+  /// Returns current seed instance or null if no seed found.
+  /// If no seed found, some wrong happened (app should be logged out).
+  Future<Seed?> _tryUpdateCurrentKey(
+    String? currentKey,
+    SeedList list,
+  ) async {
+    final seed = _getCurrentSeed(currentKey, list);
+    if (seed != null &&
+        currentKey != null &&
+        seed.findKeyByPublicKey(currentKey)?.publicKey == currentKey) {
+      return seed;
+    } else if (seed != null) {
+      // returned seed is not same as [currentKey], update it
+      await currentKeyService.changeCurrentKey(seed.publicKey);
+
+      return seed;
+    }
+
+    return null;
+  }
+
+  /// Get instance of seed by its public key.
+  /// Or get any first available seed if [currentKey] is null.
+  Seed? _getCurrentSeed(String? currentKey, SeedList list) {
+    if (currentKey == null) {
+      // if no current key, try to find any available
+      final foundKey = list.seeds.firstOrNull?.publicKey;
+      if (foundKey != null) {
+        return list.findSeedByAnyPublicKey(foundKey);
+      }
+
+      // no any key in list
+      return null;
+    }
+
+    return list.findSeedByAnyPublicKey(currentKey);
+  }
+}

--- a/lib/app/service/service.dart
+++ b/lib/app/service/service.dart
@@ -1,5 +1,7 @@
 export 'app_lifecycle_service.dart';
 export 'biometry_service.dart';
+export 'currency_convert_service.dart';
+export 'current_seed_service.dart';
 export 'messenger/messenger.dart';
 export 'migration_service.dart';
 export 'navigation/navigation.dart';

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -50,6 +50,8 @@ Future<void> bootstrap(
       await configureConnectionService();
       await configureBiometry();
 
+      await configureFeatureServices();
+
       FlutterError.onError = (details) {
         log.severe(details.exceptionAsString(), details, details.stack);
       };

--- a/lib/bootstrap/bootstrap.dart
+++ b/lib/bootstrap/bootstrap.dart
@@ -1,6 +1,7 @@
 export 'biometry.dart';
 export 'connection_service.dart';
 export 'encrypted_storage.dart';
+export 'feature_services.dart';
 export 'logger.dart';
 export 'migrate_storage.dart';
 export 'navigation_service.dart';

--- a/lib/bootstrap/feature_services.dart
+++ b/lib/bootstrap/feature_services.dart
@@ -1,0 +1,13 @@
+import 'package:app/app/service/service.dart';
+import 'package:app/di/di.dart';
+
+import 'package:logging/logging.dart';
+
+/// This is a method that allows configure some feature-related services
+Future<void> configureFeatureServices() async {
+  final log = Logger('bootstrap')
+    ..finest('CurrentSeedService initializating...');
+
+  await inject<CurrentSeedService>().init();
+  log.finest('CurrentSeedService initialized');
+}

--- a/lib/feature/add_seed/check_seed_phrase/view/check_seed_phrase_page.dart
+++ b/lib/feature/add_seed/check_seed_phrase/view/check_seed_phrase_page.dart
@@ -9,7 +9,7 @@ import 'package:ui_components_lib/ui_components_lib.dart';
 /// {@template check_seed_phrase_page}
 /// Entry point to check if user wrote down seed phrase correctly.
 /// {@endtemplate}
-class CheckSeedPhrasePage extends StatefulWidget {
+class CheckSeedPhrasePage extends StatelessWidget {
   /// {@macro check_seed_phrase_page}
   const CheckSeedPhrasePage({
     required this.extra,
@@ -18,19 +18,14 @@ class CheckSeedPhrasePage extends StatefulWidget {
 
   final CreateSeedRouteExtra extra;
 
-  @override
-  State<CheckSeedPhrasePage> createState() => _CheckSeedPhrasePageState();
-}
-
-class _CheckSeedPhrasePageState extends State<CheckSeedPhrasePage> {
   void _navigateToPassword(BuildContext context) =>
-      context.goFurther(AppRoute.createSeedPassword.path, extra: widget.extra);
+      context.goFurther(AppRoute.createSeedPassword.path, extra: extra);
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider<CheckSeedPhraseCubit>(
       create: (context) => CheckSeedPhraseCubit(
-        widget.extra.phrase,
+        extra.phrase,
         () => _navigateToPassword(context),
       )..initAnswers(),
       child: Scaffold(

--- a/lib/feature/add_seed/create_password/cubit/create_seed_password_cubit.dart
+++ b/lib/feature/add_seed/create_password/cubit/create_seed_password_cubit.dart
@@ -81,10 +81,12 @@ class CreateSeedPasswordCubit extends Cubit<CreateSeedPasswordState> {
         final publicKey = await nekoton.addSeed(
           phrase: phrase,
           password: passwordController.text,
+          name: name,
         );
         if (setCurrentKey) {
           await currentKeyService.changeCurrentKey(publicKey);
         }
+        completeCallback();
       } catch (e) {
         Logger('CreateSeedPasswordCubit').severe(e);
         emit(state.copyWith(isLoading: false));

--- a/lib/feature/add_seed/create_password/view/create_seed_password_page.dart
+++ b/lib/feature/add_seed/create_password/view/create_seed_password_page.dart
@@ -58,7 +58,8 @@ class CreateSeedPasswordProfilePage extends StatelessWidget {
         phrase: extra.phrase,
         name: extra.name,
         // When we do this flow from profile, navigate to profile root
-        completeCallback: () => context.goNamed(AppRoute.profile.path),
+        completeCallback: () =>
+            context.goNamed(AppRoute.manageSeedsAccounts.name),
       ),
       child: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),

--- a/lib/feature/add_seed/create_seed/view/create_seed_page.dart
+++ b/lib/feature/add_seed/create_seed/view/create_seed_page.dart
@@ -10,7 +10,13 @@ import 'package:ui_components_lib/ui_components_lib.dart';
 /// {@endtemplate}
 class CreateSeedPage extends StatelessWidget {
   /// {@macro create_seed_page}
-  const CreateSeedPage({super.key});
+  const CreateSeedPage({
+    this.name,
+    super.key,
+  });
+
+  /// Optional name that could be set in profile section.
+  final String? name;
 
   @override
   Widget build(BuildContext context) {
@@ -24,14 +30,14 @@ class CreateSeedPage extends StatelessWidget {
           checkCallback: (List<String> phrase) {
             context.goFurther(
               AppRoute.checkSeed.path,
-              extra: CreateSeedRouteExtra(phrase: phrase),
+              extra: CreateSeedRouteExtra(phrase: phrase, name: name),
             );
           },
           // ignore: prefer-extracting-callbacks
           skipCallback: (List<String> phrase) {
             context.goFurther(
               AppRoute.createSeedPassword.path,
-              extra: CreateSeedRouteExtra(phrase: phrase),
+              extra: CreateSeedRouteExtra(phrase: phrase, name: name),
             );
           },
         ),

--- a/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
+++ b/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
@@ -11,19 +11,14 @@ const enterSeedNameName = 'name';
 
 /// Commands that will be used to choose where to navigate after entering name
 enum EnterSeedNameCommand {
-  import('import'),
-  create('create');
-
-  const EnterSeedNameCommand(this.name);
-
-  final String name;
+  import,
+  create;
 
   static EnterSeedNameCommand getByName(String? name) {
-    // ignore: prefer-enums-by-name
-    return EnterSeedNameCommand.values.firstWhere(
-      (element) => element.name == name,
-      orElse: () => create,
-    );
+    if (name == null || EnterSeedNameCommand.values.asNameMap()[name] == null) {
+      return create;
+    }
+    return EnterSeedNameCommand.values.asNameMap()[name]!;
   }
 }
 

--- a/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
+++ b/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
@@ -3,9 +3,29 @@ import 'package:app/feature/add_seed/enter_seed_name/view/enter_seed_name_view.d
 import 'package:flutter/material.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
+/// Name of path field for navigation
+const enterSeedNameCommand = 'command';
+
+/// Name of path field for navigation
+const enterSeedNameName = 'name';
+
 /// Commands that will be used to choose where to navigate after entering name
-const enterSeedNameImportCommand = 'import';
-const enterSeedNameCreateCommand = 'create';
+enum EnterSeedNameCommand {
+  import('import'),
+  create('create');
+
+  const EnterSeedNameCommand(this.name);
+
+  final String name;
+
+  static EnterSeedNameCommand getByName(String? name) {
+    // ignore: prefer-enums-by-name
+    return EnterSeedNameCommand.values.firstWhere(
+      (element) => element.name == name,
+      orElse: () => create,
+    );
+  }
+}
 
 /// {@template enter_seed_name_create_page}
 /// Page that allows user to enter seed name, used only in profile section as
@@ -14,11 +34,11 @@ const enterSeedNameCreateCommand = 'create';
 class EnterSeedNamePage extends StatelessWidget {
   /// {@macro enter_seed_name_create_page}
   const EnterSeedNamePage({
-    required this.command,
+    required this.commandName,
     super.key,
   });
 
-  final String command;
+  final String? commandName;
 
   @override
   Widget build(BuildContext context) {
@@ -30,10 +50,17 @@ class EnterSeedNamePage extends StatelessWidget {
         body: EnterSeedNameView(
           // ignore: prefer-extracting-callbacks
           callback: (name) {
-            final query = name == null ? null : {'name': name};
-            final path = command == enterSeedNameImportCommand
-                ? AppRoute.enterSeed.pathWithQuery(query)
-                : AppRoute.createSeed.pathWithQuery(query);
+            final command = EnterSeedNameCommand.getByName(commandName);
+
+            final path = switch (command) {
+              EnterSeedNameCommand.import => name == null
+                  ? AppRoute.enterSeed.path
+                  : AppRoute.enterSeedNamed.pathWithData(name),
+              EnterSeedNameCommand.create => name == null
+                  ? AppRoute.createSeed.path
+                  : AppRoute.createSeedNamed.pathWithData(name),
+            };
+
             context.goFurther(path);
           },
         ),

--- a/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
+++ b/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
@@ -1,21 +1,24 @@
 import 'package:app/app/router/app_route.dart';
-import 'package:app/feature/add_seed/create_password/create_password.dart';
 import 'package:app/feature/add_seed/enter_seed_name/view/enter_seed_name_view.dart';
 import 'package:flutter/material.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
-/// {@template enter_seed_name_page}
-/// Page that allows user to enter seed name, used only in profile section
-/// during seed adding.
+/// Commands that will be used to choose where to navigate after entering name
+const enterSeedNameImportCommand = 'import';
+const enterSeedNameCreateCommand = 'create';
+
+/// {@template enter_seed_name_create_page}
+/// Page that allows user to enter seed name, used only in profile section as
+/// a STARTING screen in seed CREATING or IMPORTING flows.
 /// {@endtemplate}
 class EnterSeedNamePage extends StatelessWidget {
-  /// {@macro enter_seed_name_page}
+  /// {@macro enter_seed_name_create_page}
   const EnterSeedNamePage({
-    required this.extra,
+    required this.command,
     super.key,
   });
 
-  final CreateSeedRouteExtra extra;
+  final String command;
 
   @override
   Widget build(BuildContext context) {
@@ -26,11 +29,12 @@ class EnterSeedNamePage extends StatelessWidget {
         appBar: const DefaultAppBar(),
         body: EnterSeedNameView(
           // ignore: prefer-extracting-callbacks
-          callback: (String? name) {
-            context.goFurther(
-              AppRoute.createSeedPassword.path,
-              extra: CreateSeedRouteExtra(phrase: extra.phrase, name: name),
-            );
+          callback: (name) {
+            final query = name == null ? null : {'name': name};
+            final path = command == enterSeedNameImportCommand
+                ? AppRoute.enterSeed.pathWithQuery(query)
+                : AppRoute.createSeed.pathWithQuery(query);
+            context.goFurther(path);
           },
         ),
       ),

--- a/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_view.dart
+++ b/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_view.dart
@@ -42,23 +42,30 @@ class _EnterSeedNameViewState extends State<EnterSeedNameView> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              LocaleKeys.seedPhraseNameTitle.tr(),
-              style: StyleRes.h1.copyWith(color: colors.textPrimary),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    Text(
+                      LocaleKeys.enterSeedNameScreenTitle.tr(),
+                      style: StyleRes.h1.copyWith(color: colors.textPrimary),
+                    ),
+                    const SizedBox(height: DimensSize.d12),
+                    Text(
+                      LocaleKeys.enterSeedNameScreenDescription.tr(),
+                      style: StyleRes.primaryRegular
+                          .copyWith(color: colors.textPrimary),
+                    ),
+                    const SizedBox(height: DimensSize.d24),
+                    CommonInput(
+                      controller: nameController,
+                      titleText: LocaleKeys.seedName.tr(),
+                      onSubmitted: (_) => _nextAction(),
+                    ),
+                  ],
+                ),
+              ),
             ),
-            const SizedBox(height: DimensSize.d12),
-            Text(
-              LocaleKeys.seedPhraseNameDescription.tr(),
-              style:
-                  StyleRes.primaryRegular.copyWith(color: colors.textPrimary),
-            ),
-            const SizedBox(height: DimensSize.d20),
-            CommonInput(
-              controller: nameController,
-              hintText: LocaleKeys.seedName.tr(),
-              onSubmitted: (_) => _nextAction(),
-            ),
-            const Spacer(),
             CommonButton.primary(
               text: LocaleKeys.continueWord.tr(),
               onPressed: _nextAction,

--- a/lib/feature/add_seed/enter_seed_phrase/view/enter_seed_phrase_page.dart
+++ b/lib/feature/add_seed/enter_seed_phrase/view/enter_seed_phrase_page.dart
@@ -10,7 +10,13 @@ import 'package:ui_components_lib/ui_components_lib.dart';
 /// {@endtemplate}
 class EnterSeedPhrasePage extends StatelessWidget {
   /// {@macro enter_seed_phrase_page}
-  const EnterSeedPhrasePage({super.key});
+  const EnterSeedPhrasePage({
+    this.name,
+    super.key,
+  });
+
+  /// Optional name that could be set in profile section.
+  final String? name;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +24,7 @@ class EnterSeedPhrasePage extends StatelessWidget {
       create: (context) => EnterSeedPhraseCubit(
         (phrase) => context.goFurther(
           AppRoute.createSeedPassword.path,
-          extra: CreateSeedRouteExtra(phrase: phrase),
+          extra: CreateSeedRouteExtra(phrase: phrase, name: name),
         ),
       )..init(),
       child: GestureDetector(

--- a/lib/feature/error/view/error_page.dart
+++ b/lib/feature/error/view/error_page.dart
@@ -1,12 +1,17 @@
 import 'package:app/feature/error/view/error_view.dart';
 import 'package:flutter/material.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
 
 class ErrorPage extends StatelessWidget {
   const ErrorPage(this.error, {super.key});
+
   final Exception? error;
 
   @override
   Widget build(BuildContext context) {
-    return const ErrorView();
+    return const Scaffold(
+      appBar: DefaultAppBar(),
+      body: ErrorView(),
+    );
   }
 }

--- a/lib/feature/error/view/error_view.dart
+++ b/lib/feature/error/view/error_view.dart
@@ -1,12 +1,24 @@
+import 'package:app/app/router/app_route.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
 
 class ErrorView extends StatelessWidget {
   const ErrorView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Error'),
+    return Center(
+      child: ContainerColumn(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text('Error'),
+          CommonButton(
+            text: 'Go to wallet',
+            onPressed: () => context.goNamed(AppRoute.wallet.name),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/feature/profile/bloc/profile_event.dart
+++ b/lib/feature/profile/bloc/profile_event.dart
@@ -9,10 +9,7 @@ class ProfileEvent with _$ProfileEvent {
   const factory ProfileEvent.logOut() = _LogOut;
 
   /// This is internal event to update data reacting for some subscription
-  const factory ProfileEvent.updateData(
-    String? currentKey,
-    SeedList list,
-  ) = _UpdateData;
+  const factory ProfileEvent.updateData(Seed? currentSeed) = _UpdateData;
 
   /// Export seed phrase with early entered password.
   /// This means, that user want to export current seed (from currentKey)

--- a/lib/feature/profile/manage_seeds_accounts/cubit/cubit.dart
+++ b/lib/feature/profile/manage_seeds_accounts/cubit/cubit.dart
@@ -1,0 +1,1 @@
+export 'manage_seeds_accounts_cubit.dart';

--- a/lib/feature/profile/manage_seeds_accounts/cubit/manage_seeds_accounts_cubit.dart
+++ b/lib/feature/profile/manage_seeds_accounts/cubit/manage_seeds_accounts_cubit.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:app/app/service/service.dart';
+import 'package:bloc/bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+
+part 'manage_seeds_accounts_state.dart';
+
+part 'manage_seeds_accounts_cubit.freezed.dart';
+
+/// This is a bloc that displays list of user's seeds.
+///
+/// This displays list of available seeds and current seed.
+class ManageSeedsAccountsCubit extends Cubit<ManageSeedsAccountsState> {
+  ManageSeedsAccountsCubit(
+    this.nekotonRepository,
+    this.currentSeedService,
+  ) : super(
+          ManageSeedsAccountsState.data(
+            currentSeed: currentSeedService.currentSeed,
+            seeds: _mapSeedList(nekotonRepository.seedList),
+          ),
+        );
+
+  final NekotonRepository nekotonRepository;
+  final CurrentSeedService currentSeedService;
+
+  late StreamSubscription<SeedList> _seedListSubscription;
+  late StreamSubscription<Seed?> _currentSeedSubscription;
+
+  @override
+  Future<void> close() {
+    _seedListSubscription.cancel();
+    _currentSeedSubscription.cancel();
+
+    return super.close();
+  }
+
+  void init() {
+    // skip 1 to avoid duplicate init from constructor
+    _currentSeedSubscription =
+        currentSeedService.currentSeedStream.skip(1).listen(
+      (currentSeed) {
+        emit(
+          ManageSeedsAccountsState.data(
+            currentSeed: currentSeed,
+            seeds: _mapSeedList(nekotonRepository.seedList),
+          ),
+        );
+      },
+    );
+    _seedListSubscription = nekotonRepository.seedListStream.skip(1).listen(
+      (seeds) {
+        emit(
+          ManageSeedsAccountsState.data(
+            currentSeed: currentSeedService.currentSeed,
+            seeds: _mapSeedList(seeds),
+          ),
+        );
+      },
+    );
+  }
+
+  static List<Seed> _mapSeedList(SeedList list) {
+    return List.from(list.seeds)
+      ..sort((a, b) => a.publicKey.compareTo(b.publicKey));
+  }
+}

--- a/lib/feature/profile/manage_seeds_accounts/cubit/manage_seeds_accounts_state.dart
+++ b/lib/feature/profile/manage_seeds_accounts/cubit/manage_seeds_accounts_state.dart
@@ -1,0 +1,9 @@
+part of 'manage_seeds_accounts_cubit.dart';
+
+@freezed
+class ManageSeedsAccountsState with _$ManageSeedsAccountsState {
+  const factory ManageSeedsAccountsState.data({
+    required Seed? currentSeed,
+    required List<Seed> seeds,
+  }) = _Data;
+}

--- a/lib/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart
+++ b/lib/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart
@@ -1,0 +1,3 @@
+export 'cubit/cubit.dart';
+export 'view/view.dart';
+export 'widgets/widgets.dart';

--- a/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_page.dart
+++ b/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_page.dart
@@ -1,0 +1,26 @@
+import 'package:app/app/service/service.dart';
+import 'package:app/di/di.dart';
+import 'package:app/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+import 'package:ui_components_lib/components/common/common.dart';
+
+/// Root widget for manage seeds and accounts feature
+class ManageSeedsAccountsPage extends StatelessWidget {
+  const ManageSeedsAccountsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<ManageSeedsAccountsCubit>(
+      create: (_) => ManageSeedsAccountsCubit(
+        inject<NekotonRepository>(),
+        inject<CurrentSeedService>(),
+      )..init(),
+      child: const Scaffold(
+        appBar: DefaultAppBar(),
+        body: ManageSeedsAccountsView(),
+      ),
+    );
+  }
+}

--- a/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_view.dart
+++ b/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_view.dart
@@ -1,0 +1,145 @@
+import 'package:app/app/router/app_route.dart';
+import 'package:app/feature/add_seed/enter_seed_name/enter_seed_name.dart';
+import 'package:app/feature/profile/manage_seeds_accounts/manage_seeds_accounts.dart';
+import 'package:app/generated/generated.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
+
+/// Main widget that displays content of manage seeds and accounts feature
+class ManageSeedsAccountsView extends StatelessWidget {
+  const ManageSeedsAccountsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ManageSeedsAccountsCubit, ManageSeedsAccountsState>(
+      builder: (context, state) {
+        final colors = context.themeStyle.colors;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: DimensSize.d12,
+            horizontal: DimensSize.d16,
+          ),
+          child: SeparatedColumn(
+            separatorSize: DimensSize.d16,
+            children: [
+              Text(
+                LocaleKeys.manageSeedsAndAccounts.tr(),
+                style: StyleRes.h1.copyWith(color: colors.textPrimary),
+              ),
+              SeparatedRow(
+                children: [
+                  Expanded(
+                    child: CommonCard(
+                      height: DimensSize.d76,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: DimensSize.d16,
+                      ),
+                      topSubtitleText: LocaleKeys.currentSeed.tr(),
+                      titleText: state.currentSeed?.name ?? '',
+                    ),
+                  ),
+                  Expanded(
+                    child: CommonCard(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: DimensSize.d16,
+                      ),
+                      height: DimensSize.d76,
+                      topSubtitleText: LocaleKeys.totalBalance.tr(),
+                      titleText: '0 USD',
+                    ),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: ShapedContainerColumn(
+                    margin: EdgeInsets.zero,
+                    titleText: LocaleKeys.seedPhrases.tr(),
+                    children: state.seeds
+                        .map(
+                          (seed) => _mapSeedTile(
+                            seed: seed,
+                            currentSeed: state.currentSeed,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+              const SizedBox(height: DimensSize.d8),
+              CommonButton(
+                leading: CommonButtonIconWidget.svg(
+                  svg: Assets.images.plus.path,
+                ),
+                text: LocaleKeys.addSeedPhrase.tr(),
+                onPressed: () => _showAddSeedSheet(context),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showAddSeedSheet(BuildContext context) async {
+    final selected = await showSelectAddSeedTypeSheet(context);
+
+    if (context.mounted && selected != null) {
+      switch (selected) {
+        case SelectAddSeedType.create:
+          context.goFurther(
+            AppRoute.enterSeedName.pathWithData(enterSeedNameCreateCommand),
+          );
+        case SelectAddSeedType.import:
+          context.goFurther(
+            AppRoute.enterSeedName.pathWithData(enterSeedNameImportCommand),
+          );
+      }
+    }
+  }
+
+  Widget _mapSeedTile({
+    required Seed seed,
+    required Seed? currentSeed,
+  }) {
+    return Builder(
+      builder: (context) {
+        final colors = context.themeStyle.colors;
+
+        return CommonListTile(
+          padding: EdgeInsets.zero,
+          leading: CommonBackgroundedIconWidget.svg(
+            svg: Assets.images.sparxLogoSmall.path,
+            useDefaultColor: false,
+          ),
+          titleText: seed.name,
+          subtitleText: LocaleKeys.publicKeysWithData.plural(
+            seed.allKeys.length,
+            namedArgs: {'data': '0 USD'},
+          ),
+          trailing: SeparatedRow(
+            separatorSize: DimensSize.d16,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (currentSeed?.publicKey == seed.publicKey)
+                CommonIconWidget.svg(
+                  svg: Assets.images.check.path,
+                  color: colors.textPrimary,
+                ),
+              CommonIconButton.svg(
+                color: colors.textSecondary,
+                svg: Assets.images.settings.path,
+                buttonType: EverButtonType.ghost,
+                onPressed: () => showSeedSettingsSheet(context, seed.publicKey),
+                innerPadding: EdgeInsets.zero,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_view.dart
+++ b/lib/feature/profile/manage_seeds_accounts/view/manage_seeds_accounts_view.dart
@@ -91,11 +91,13 @@ class ManageSeedsAccountsView extends StatelessWidget {
       switch (selected) {
         case SelectAddSeedType.create:
           context.goFurther(
-            AppRoute.enterSeedName.pathWithData(enterSeedNameCreateCommand),
+            AppRoute.enterSeedName
+                .pathWithData(EnterSeedNameCommand.create.name),
           );
         case SelectAddSeedType.import:
           context.goFurther(
-            AppRoute.enterSeedName.pathWithData(enterSeedNameImportCommand),
+            AppRoute.enterSeedName
+                .pathWithData(EnterSeedNameCommand.import.name),
           );
       }
     }

--- a/lib/feature/profile/manage_seeds_accounts/view/view.dart
+++ b/lib/feature/profile/manage_seeds_accounts/view/view.dart
@@ -1,0 +1,2 @@
+export 'manage_seeds_accounts_page.dart';
+export 'manage_seeds_accounts_view.dart';

--- a/lib/feature/profile/manage_seeds_accounts/widgets/seed_settings_sheet.dart
+++ b/lib/feature/profile/manage_seeds_accounts/widgets/seed_settings_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:app/app/service/service.dart';
+import 'package:app/di/di.dart';
+import 'package:app/generated/generated.dart';
+import 'package:flutter/material.dart';
+import 'package:nekoton_repository/nekoton_repository.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
+
+/// Helper function that shows [SeedSettingsSheet]
+void showSeedSettingsSheet(
+  BuildContext context,
+  String publicKey,
+) {
+  showCommonBottomSheet<void>(
+    context: context,
+    useAppBackgroundColor: true,
+    title: LocaleKeys.settingsOfSeed.tr(),
+    body: (_, __) => SeedSettingsSheet(publicKey: publicKey),
+  );
+}
+
+/// This is a widget that displays settings of seed
+class SeedSettingsSheet extends StatelessWidget {
+  const SeedSettingsSheet({
+    required this.publicKey,
+    super.key,
+  });
+
+  final String publicKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.themeStyle.colors;
+    final currentKeyService = inject<CurrentKeyService>();
+
+    final currentKey = currentKeyService.currentKey;
+
+    void actionWithPop(VoidCallback action) {
+      action();
+      Navigator.of(context).pop();
+    }
+
+    return ShapedContainerColumn(
+      margin: EdgeInsets.zero,
+      mainAxisSize: MainAxisSize.min,
+      separator: const CommonDivider(),
+      children: [
+        if (publicKey != currentKey)
+          CommonListTile(
+            onPressed: () => actionWithPop(
+              () => currentKeyService.changeCurrentKey(publicKey),
+            ),
+            titleText: LocaleKeys.useThisSeed.tr(),
+            trailing: CommonIconWidget.svg(
+              svg: Assets.images.checkRounded.path,
+              color: colors.textPrimary,
+            ),
+          ),
+        CommonListTile(
+          onPressed: () => actionWithPop(
+            // ignore: no-empty-block
+            () {},
+          ),
+          titleText: LocaleKeys.exportWord.tr(),
+          trailing: CommonIconWidget.svg(
+            svg: Assets.images.export.path,
+            color: colors.textPrimary,
+          ),
+        ),
+        CommonListTile(
+          onPressed: () => actionWithPop(
+            // ignore: no-empty-block
+            () {},
+          ),
+          titleText: LocaleKeys.changePassword.tr(),
+          trailing: CommonIconWidget.svg(
+            svg: Assets.images.key.path,
+            color: colors.textPrimary,
+          ),
+        ),
+        if (publicKey != currentKey)
+          CommonListTile(
+            onPressed: () => actionWithPop(
+              () => inject<NekotonRepository>()
+                  .seedList
+                  .findSeed(publicKey)
+                  ?.remove(),
+            ),
+            contentColor: colors.alert,
+            titleText: LocaleKeys.deleteWord.tr(),
+            trailing: CommonIconWidget.svg(svg: Assets.images.trash.path),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/feature/profile/manage_seeds_accounts/widgets/select_add_seed_type_sheet.dart
+++ b/lib/feature/profile/manage_seeds_accounts/widgets/select_add_seed_type_sheet.dart
@@ -1,0 +1,49 @@
+import 'package:app/generated/generated.dart';
+import 'package:flutter/material.dart';
+import 'package:ui_components_lib/ui_components_lib.dart';
+
+enum SelectAddSeedType { create, import }
+
+/// Helper function that shows [SelectAddSeedTypeSheet]
+Future<SelectAddSeedType?> showSelectAddSeedTypeSheet(BuildContext context) {
+  return showCommonBottomSheet<SelectAddSeedType>(
+    context: context,
+    title: LocaleKeys.addNewSeedPhrase.tr(),
+    useAppBackgroundColor: true,
+    body: (_, __) => const SelectAddSeedTypeSheet(),
+  );
+}
+
+/// Widget that allows select type of seed phrase adding
+class SelectAddSeedTypeSheet extends StatelessWidget {
+  const SelectAddSeedTypeSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.themeStyle.colors;
+
+    return ShapedContainerColumn(
+      margin: EdgeInsets.zero,
+      mainAxisSize: MainAxisSize.min,
+      separator: const CommonDivider(),
+      children: [
+        CommonListTile(
+          onPressed: () => Navigator.of(context).pop(SelectAddSeedType.create),
+          titleText: LocaleKeys.createNewSeed.tr(),
+          trailing: CommonIconWidget.svg(
+            svg: Assets.images.plus.path,
+            color: colors.textPrimary,
+          ),
+        ),
+        CommonListTile(
+          onPressed: () => Navigator.of(context).pop(SelectAddSeedType.import),
+          titleText: LocaleKeys.importSeed.tr(),
+          trailing: CommonIconWidget.svg(
+            svg: Assets.images.import.path,
+            color: colors.textPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/feature/profile/manage_seeds_accounts/widgets/widgets.dart
+++ b/lib/feature/profile/manage_seeds_accounts/widgets/widgets.dart
@@ -1,0 +1,2 @@
+export 'seed_settings_sheet.dart';
+export 'select_add_seed_type_sheet.dart';

--- a/lib/feature/profile/view/profile_page.dart
+++ b/lib/feature/profile/view/profile_page.dart
@@ -15,7 +15,7 @@ class ProfilePage extends StatelessWidget {
     return BlocProvider(
       create: (context) => ProfileBloc(
         inject<NekotonRepository>(),
-        inject<CurrentKeyService>(),
+        inject<CurrentSeedService>(),
       )..add(const ProfileEvent.init()),
       child: BlocConsumer<ProfileBloc, ProfileState>(
         listener: (context, state) {

--- a/lib/feature/profile/view/profile_view.dart
+++ b/lib/feature/profile/view/profile_view.dart
@@ -1,3 +1,4 @@
+import 'package:app/app/router/app_route.dart';
 import 'package:app/feature/profile/bloc/profile_bloc.dart';
 import 'package:app/generated/assets.gen.dart';
 import 'package:app/generated/locale_keys.g.dart';
@@ -31,7 +32,7 @@ class ProfileView extends StatelessWidget {
             ),
             const SizedBox(height: DimensSize.d4),
             Text(
-              currentSeed?.masterKey.key.name ?? '',
+              currentSeed?.name ?? '',
               style: StyleRes.h2.copyWith(color: colors.textPrimary),
             ),
             const SizedBox(height: DimensSize.d16),
@@ -55,8 +56,8 @@ class ProfileView extends StatelessWidget {
                   trailing: CommonButtonIconWidget.svg(
                     svg: Assets.images.caretRight.path,
                   ),
-                  // ignore: no-empty-block
-                  onPressed: () {},
+                  onPressed: () =>
+                      context.goFurther(AppRoute.manageSeedsAccounts.path),
                 ),
                 _profileTile(
                   leadingIcon: Assets.images.currency.path,

--- a/packages/nekoton_repository/lib/src/models/seed.dart
+++ b/packages/nekoton_repository/lib/src/models/seed.dart
@@ -21,6 +21,12 @@ class Seed extends Equatable {
   /// This key is derived directly from seed phrase.
   final SeedKey masterKey;
 
+  /// Proxy getter of name of master key
+  String get name => masterKey.key.name;
+
+  /// Proxy getter of public key of master key
+  String get publicKey => masterKey.key.publicKey;
+
   /// List of derived keys of [masterKey].
   /// This list do not contains [masterKey].
   final List<SeedKey> subKeys;
@@ -30,7 +36,7 @@ class Seed extends Equatable {
 
   /// Get instance of SeedKey if [publicKey] is part of this seed.
   SeedKey? findKeyByPublicKey(String publicKey) =>
-      allKeys.firstWhereOrNull((key) => key.key.publicKey == publicKey);
+      allKeys.firstWhereOrNull((key) => key.publicKey == publicKey);
 
   /// Derive keys from [masterKey] this call adds list of sub keys to
   /// [subKeys].
@@ -43,7 +49,7 @@ class Seed extends Equatable {
       GetIt.instance<SeedKeyRepository>().deriveKeys(
         accountIds: accountIds,
         password: password,
-        masterKey: masterKey.key.publicKey,
+        masterKey: masterKey.publicKey,
       );
 
   /// Change password of seed phrase.
@@ -52,19 +58,19 @@ class Seed extends Equatable {
     required String newPassword,
   }) =>
       GetIt.instance<SeedKeyRepository>().changeSeedPassword(
-        publicKey: masterKey.key.publicKey,
+        publicKey: masterKey.publicKey,
         oldPassword: oldPassword,
         newPassword: newPassword,
-        isLegacy: masterKey.key.isLegacy,
+        isLegacy: masterKey.isLegacy,
       );
 
   /// Return seeds phrase of this seed.
   /// Do not works for ledger key.
   Future<List<String>> exportKey(String password) =>
       GetIt.instance<SeedKeyRepository>().exportKey(
-        masterKey: masterKey.key.publicKey,
+        masterKey: masterKey.publicKey,
         password: password,
-        isLegacy: masterKey.key.isLegacy,
+        isLegacy: masterKey.isLegacy,
       );
 
   /// This method allows remove full seed and all related keys (master and sub)

--- a/packages/nekoton_repository/lib/src/models/seed_key.dart
+++ b/packages/nekoton_repository/lib/src/models/seed_key.dart
@@ -18,6 +18,15 @@ class SeedKey extends Equatable {
   /// List of accounts that specified for this [key]
   final AccountList accountList;
 
+  /// Proxy getter of name of key
+  String get name => key.name;
+
+  /// Proxy getter of public key of key
+  String get publicKey => key.publicKey;
+
+  /// Proxy getter of legacy flag of key
+  bool get isLegacy => key.isLegacy;
+
   /// Get account instance by it's address.
   /// This is a heavy operation and must not be called during build.
   /// This method can be helpful in browser.
@@ -49,12 +58,12 @@ class SeedKey extends Equatable {
         publicKey: key.publicKey,
         masterKey: key.masterKey,
         name: name,
-        isLegacy: key.isLegacy,
+        isLegacy: isLegacy,
       );
 
   /// Input that can be used to decrypt/encrypt methods.
   /// [password] is the password of the seed
-  SignInput signInput(String password) => key.isLegacy
+  SignInput signInput(String password) => isLegacy
       ? EncryptedKeyPassword(
           publicKey: key.publicKey,
           password: Password.explicit(

--- a/packages/nekoton_repository/lib/src/models/seed_list.dart
+++ b/packages/nekoton_repository/lib/src/models/seed_list.dart
@@ -52,7 +52,7 @@ class SeedList extends Equatable {
   ///
   /// Returns found key or null.
   SeedKey? findSeedKey(String publicKey) =>
-      _allKeys.firstWhereOrNull((k) => k.key.publicKey == publicKey);
+      _allKeys.firstWhereOrNull((k) => k.publicKey == publicKey);
 
   /// Get account instance by it's address.
   /// This is a heavy operation and must not be called during build.
@@ -91,7 +91,7 @@ class SeedList extends Equatable {
     required String publicKey,
     required String password,
   }) {
-    final key = _allKeys.firstWhere((k) => k.key.publicKey == publicKey);
+    final key = _allKeys.firstWhere((k) => k.publicKey == publicKey);
 
     return GetIt.instance<SeedKeyRepository>().encrypt(
       data: data,
@@ -108,7 +108,7 @@ class SeedList extends Equatable {
     required String publicKey,
     required String password,
   }) {
-    final key = _allKeys.firstWhere((k) => k.key.publicKey == publicKey);
+    final key = _allKeys.firstWhere((k) => k.publicKey == publicKey);
 
     return GetIt.instance<SeedKeyRepository>().decrypt(
       data: data,
@@ -125,7 +125,7 @@ class SeedList extends Equatable {
     required String password,
     required int? signatureId,
   }) {
-    final key = _allKeys.firstWhere((k) => k.key.publicKey == publicKey);
+    final key = _allKeys.firstWhere((k) => k.publicKey == publicKey);
 
     return GetIt.instance<SeedKeyRepository>().sign(
       data: data,
@@ -143,7 +143,7 @@ class SeedList extends Equatable {
     required String password,
     required int? signatureId,
   }) {
-    final key = _allKeys.firstWhere((k) => k.key.publicKey == publicKey);
+    final key = _allKeys.firstWhere((k) => k.publicKey == publicKey);
 
     return GetIt.instance<SeedKeyRepository>().signData(
       data: data,
@@ -161,7 +161,7 @@ class SeedList extends Equatable {
     required String password,
     required int? signatureId,
   }) {
-    final key = _allKeys.firstWhere((k) => k.key.publicKey == publicKey);
+    final key = _allKeys.firstWhere((k) => k.publicKey == publicKey);
 
     return GetIt.instance<SeedKeyRepository>().signRawData(
       data: data,

--- a/packages/nekoton_repository/lib/src/repositories/seed_repository/seed_repository_impl.dart
+++ b/packages/nekoton_repository/lib/src/repositories/seed_repository/seed_repository_impl.dart
@@ -308,11 +308,11 @@ mixin SeedKeyRepositoryImpl on TransportRepository
   @override
   Future<List<String>> removeKeys(List<SeedKey> keys) async {
     final removed = await keyStore.removeKeys(
-      publicKeys: keys.map((e) => e.key.publicKey).toList(),
+      publicKeys: keys.map((e) => e.publicKey).toList(),
     );
     unawaited(
       triggerRemovingAccounts(
-        keys.where((k) => removed.contains(k.key.publicKey)),
+        keys.where((k) => removed.contains(k.publicKey)),
       ),
     );
 

--- a/packages/nekoton_repository/lib/src/repositories/seed_repository/seed_repository_impl.dart
+++ b/packages/nekoton_repository/lib/src/repositories/seed_repository/seed_repository_impl.dart
@@ -55,6 +55,8 @@ mixin SeedKeyRepositoryImpl on TransportRepository
         isLegacy ? const MnemonicType.legacy() : const MnemonicType.labs(0);
     final phraseStr = phrase.join(' ');
 
+    name = name?.isEmpty ?? true ? null : name;
+
     final createKeyInput = isLegacy
         ? EncryptedKeyCreateInput(
             name: name,

--- a/packages/ui_components_lib/example/lib/stories/common.dart
+++ b/packages/ui_components_lib/example/lib/stories/common.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
+const _defaultContainerSize = 3;
+
 /// Page with all colors
 class CommonStory extends StatelessWidget {
   const CommonStory({super.key});
@@ -138,6 +140,49 @@ class CommonStory extends StatelessWidget {
                   iconColor: colors.textPrimary,
                 ),
               ],
+            ),
+            const SizedBox(height: DimensSize.d24),
+
+            // containers
+            const Text('DIFFERENT CONTAINERS', style: StyleRes.h2),
+            const SizedBox(height: DimensSize.d8),
+            ShapedContainerColumn(
+              titleText: 'ShapedContainerColumn',
+              children: List.generate(
+                _defaultContainerSize,
+                (index) => CommonListTile(titleText: 'Item $index'),
+              ),
+            ),
+            const SizedBox(height: DimensSize.d8),
+            ShapedContainerColumn(
+              titleText: 'ShapedContainerColumn',
+              children: List.generate(
+                _defaultContainerSize,
+                (index) => Text('Item $index'),
+              ),
+            ),
+            const SizedBox(height: DimensSize.d8),
+            ShapedContainerColumn(
+              separator: const CommonDivider(),
+              children: List.generate(
+                _defaultContainerSize,
+                (index) => CommonListTile(titleText: 'Item $index'),
+              ),
+            ),
+            const SizedBox(height: DimensSize.d8),
+            ShapedContainerRow(
+              titleText: 'ShapedContainerRow',
+              children: List.generate(
+                _defaultContainerSize,
+                (index) => Text('Item $index'),
+              ),
+            ),
+            const SizedBox(height: DimensSize.d8),
+            ShapedContainerRow(
+              children: List.generate(
+                _defaultContainerSize,
+                (index) => Expanded(child: Text('Item $index')),
+              ),
             ),
             const SizedBox(height: DimensSize.d32),
           ],

--- a/packages/ui_components_lib/lib/components/common/common_icon.dart
+++ b/packages/ui_components_lib/lib/components/common/common_icon.dart
@@ -24,18 +24,30 @@ class CommonIconWidget extends StatelessWidget {
   /// Factory that allows creating widget with [IconData]
   factory CommonIconWidget.icon({
     required IconData icon,
+    Color? color,
     double? size,
     Key? key,
   }) =>
-      CommonIconWidget(icon: icon, size: size, key: key);
+      CommonIconWidget(
+        icon: icon,
+        size: size,
+        key: key,
+        color: color,
+      );
 
   /// Factory that allows creating widget with svg asset
   factory CommonIconWidget.svg({
     required String svg,
+    Color? color,
     double? size,
     Key? key,
   }) =>
-      CommonIconWidget(svg: svg, size: size, key: key);
+      CommonIconWidget(
+        svg: svg,
+        size: size,
+        key: key,
+        color: color,
+      );
 
   /// Data of icon that is used in [Icon]
   final IconData? icon;

--- a/packages/ui_components_lib/lib/components/common/common_list_tile.dart
+++ b/packages/ui_components_lib/lib/components/common/common_list_tile.dart
@@ -24,6 +24,7 @@ class CommonListTile extends StatelessWidget {
     this.backgroundColor,
     this.squircleRadius = DimensRadius.xMedium,
     this.padding = const EdgeInsets.symmetric(horizontal: DimensSize.d8),
+    this.contentColor,
   });
 
   /// Press callback of tile
@@ -56,6 +57,9 @@ class CommonListTile extends StatelessWidget {
   /// Padding of content inside tile, default is horizontal: DimensSize.d8.
   final EdgeInsets padding;
 
+  /// Color of text and icons inside tile
+  final Color? contentColor;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.themeStyle.colors;
@@ -63,14 +67,18 @@ class CommonListTile extends StatelessWidget {
     final title = titleText != null
         ? Text(
             titleText!,
-            style: StyleRes.button.copyWith(color: colors.textPrimary),
+            style: StyleRes.button.copyWith(
+              color: contentColor ?? colors.textPrimary,
+            ),
           )
         : titleChild;
 
     final subtitle = subtitleText != null
         ? Text(
             subtitleText!,
-            style: StyleRes.addRegular.copyWith(color: colors.textSecondary),
+            style: StyleRes.addRegular.copyWith(
+              color: contentColor ?? colors.textSecondary,
+            ),
           )
         : subtitleChild;
 
@@ -100,7 +108,7 @@ class CommonListTile extends StatelessWidget {
             ),
             if (trailing != null)
               EverButtonStyleProvider(
-                contentColor: colors.textSecondary,
+                contentColor: contentColor ?? colors.textSecondary,
                 child: trailing!,
               ),
           ],

--- a/packages/ui_components_lib/lib/components/common/container/shaped_container_column.dart
+++ b/packages/ui_components_lib/lib/components/common/container/shaped_container_column.dart
@@ -68,6 +68,7 @@ class ShapedContainerColumn extends StatelessWidget {
         child: Padding(
           padding: padding,
           child: SeparatedColumn(
+            mainAxisSize: mainAxisSize,
             crossAxisAlignment: CrossAxisAlignment.start,
             separatorSize: DimensSize.d16,
             children: [

--- a/packages/ui_components_lib/lib/components/common/container/shaped_container_column.dart
+++ b/packages/ui_components_lib/lib/components/common/container/shaped_container_column.dart
@@ -18,7 +18,9 @@ class ShapedContainerColumn extends StatelessWidget {
     this.separatorSize = DimensSize.d8,
     this.separator,
     this.mainAxisSize = MainAxisSize.max,
-    this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.crossAxisAlignment = CrossAxisAlignment.start,
+    this.mainAxisAlignment = MainAxisAlignment.start,
+    this.titleText,
   });
 
   /// See [Column.children]
@@ -46,8 +48,14 @@ class ShapedContainerColumn extends StatelessWidget {
   /// See [Column.crossAxisAlignment]
   final CrossAxisAlignment crossAxisAlignment;
 
+  /// See [Column.mainAxisAlignment]
+  final MainAxisAlignment mainAxisAlignment;
+
   /// See <ContainerColumn.separator>
   final Widget? separator;
+
+  /// Title that displays above list of content
+  final String? titleText;
 
   @override
   Widget build(BuildContext context) {
@@ -56,13 +64,30 @@ class ShapedContainerColumn extends StatelessWidget {
       child: Material(
         color: color ?? context.themeStyle.colors.backgroundSecondary,
         shape: SquircleShapeBorder(cornerRadius: squircleRadius),
-        child: ContainerColumn(
-          separator: separator,
-          separatorSize: separatorSize,
-          mainAxisSize: mainAxisSize,
-          crossAxisAlignment: crossAxisAlignment,
+        // padding here, because ContainerColumn changes alignment in a bad way
+        child: Padding(
           padding: padding,
-          children: children,
+          child: SeparatedColumn(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            separatorSize: DimensSize.d16,
+            children: [
+              if (titleText != null)
+                Text(
+                  titleText!,
+                  style: StyleRes.h2.copyWith(
+                    color: context.themeStyle.colors.textPrimary,
+                  ),
+                ),
+              SeparatedColumn(
+                separator: separator,
+                separatorSize: separatorSize,
+                mainAxisSize: mainAxisSize,
+                mainAxisAlignment: mainAxisAlignment,
+                crossAxisAlignment: crossAxisAlignment,
+                children: children,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/ui_components_lib/lib/components/common/container/shaped_container_row.dart
+++ b/packages/ui_components_lib/lib/components/common/container/shaped_container_row.dart
@@ -19,6 +19,8 @@ class ShapedContainerRow extends StatelessWidget {
     this.separator,
     this.mainAxisSize = MainAxisSize.max,
     this.crossAxisAlignment = CrossAxisAlignment.center,
+    this.mainAxisAlignment = MainAxisAlignment.start,
+    this.titleText,
   });
 
   /// See [Column.children]
@@ -40,14 +42,20 @@ class ShapedContainerRow extends StatelessWidget {
   /// See <ContainerColumn.separatorSize>
   final double? separatorSize;
 
-  /// See [Column.mainAxisSize]
+  /// See [Row.mainAxisSize]
   final MainAxisSize mainAxisSize;
 
-  /// See [Column.crossAxisAlignment]
+  /// See [Row.crossAxisAlignment]
   final CrossAxisAlignment crossAxisAlignment;
+
+  /// See [Row.mainAxisAlignment]
+  final MainAxisAlignment mainAxisAlignment;
 
   /// See <ContainerColumn.separator>
   final Widget? separator;
+
+  /// Title that displays above list of content
+  final String? titleText;
 
   @override
   Widget build(BuildContext context) {
@@ -56,13 +64,30 @@ class ShapedContainerRow extends StatelessWidget {
       child: Material(
         color: color ?? context.themeStyle.colors.backgroundSecondary,
         shape: SquircleShapeBorder(cornerRadius: squircleRadius),
-        child: ContainerRow(
-          separator: separator,
-          separatorSize: separatorSize,
-          mainAxisSize: mainAxisSize,
-          crossAxisAlignment: crossAxisAlignment,
+        // padding here, because ContainerColumn changes alignment in a bad way
+        child: Padding(
           padding: padding,
-          children: children,
+          child: SeparatedColumn(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            separatorSize: DimensSize.d16,
+            children: [
+              if (titleText != null)
+                Text(
+                  titleText!,
+                  style: StyleRes.h2.copyWith(
+                    color: context.themeStyle.colors.textPrimary,
+                  ),
+                ),
+              SeparatedRow(
+                separator: separator,
+                separatorSize: separatorSize,
+                mainAxisSize: mainAxisSize,
+                mainAxisAlignment: mainAxisAlignment,
+                crossAxisAlignment: crossAxisAlignment,
+                children: children,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
+++ b/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
-const _defaultBarrierOpacity = 0.73;
-
 /// Builder for body parameter of [showCommonBottomSheet].
 /// This allows get [ScrollController] of modal sheet and use it in scroll box.
 typedef CommonSheetBodyBuilder = Widget Function(
@@ -42,8 +40,7 @@ Future<T?> showCommonBottomSheet<T>({
     context: context,
     isDismissible: dismissible,
     useRootNavigator: useRootNavigator,
-    barrierColor:
-        barrierColor ?? Colors.black.withOpacity(_defaultBarrierOpacity),
+    barrierColor: barrierColor ?? Colors.black.withOpacity(Opac.large),
     containerWidget: (context, animation, child) => _ContainerWidget(
       animated: wrapIntoAnimatedSize,
       child: child,

--- a/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
+++ b/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
@@ -40,7 +40,7 @@ Future<T?> showCommonBottomSheet<T>({
     context: context,
     isDismissible: dismissible,
     useRootNavigator: useRootNavigator,
-    barrierColor: barrierColor,
+    barrierColor: barrierColor ?? Colors.black.withOpacity(0.73),
     containerWidget: (context, animation, child) => _ContainerWidget(
       animated: wrapIntoAnimatedSize,
       child: child,
@@ -151,7 +151,7 @@ class __ContainerWidgetState extends State<_ContainerWidget> {
       clipBehavior: Clip.antiAlias,
       decoration: const BoxDecoration(
         borderRadius: BorderRadius.vertical(
-          top: Radius.circular(DimensRadius.xMedium),
+          top: Radius.circular(DimensRadius.large),
         ),
       ),
       width: double.infinity,

--- a/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
+++ b/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
+const _defaultBarrierOpacity = 0.73;
+
 /// Builder for body parameter of [showCommonBottomSheet].
 /// This allows get [ScrollController] of modal sheet and use it in scroll box.
 typedef CommonSheetBodyBuilder = Widget Function(
@@ -40,7 +42,8 @@ Future<T?> showCommonBottomSheet<T>({
     context: context,
     isDismissible: dismissible,
     useRootNavigator: useRootNavigator,
-    barrierColor: barrierColor ?? Colors.black.withOpacity(0.73),
+    barrierColor:
+        barrierColor ?? Colors.black.withOpacity(_defaultBarrierOpacity),
     containerWidget: (context, animation, child) => _ContainerWidget(
       animated: wrapIntoAnimatedSize,
       child: child,

--- a/packages/ui_components_lib/lib/dimens.dart
+++ b/packages/ui_components_lib/lib/dimens.dart
@@ -24,6 +24,7 @@ class DimensSize {
   static const double d56 = 56;
   static const double d64 = 64;
   static const double d72 = 72;
+  static const double d76 = 76;
   static const double d92 = 92;
   static const double d100 = 100;
   static const double d148 = 148;

--- a/packages/ui_components_lib/lib/opac.dart
+++ b/packages/ui_components_lib/lib/opac.dart
@@ -1,4 +1,7 @@
 class Opac {
   /// 0.5
   static const double medium = 0.5;
+
+  /// 0.73
+  static const double large = 0.73;
 }


### PR DESCRIPTION
## Description

copilot:all

## Type of Change

- Added `ManageSeedsAndAccounts` page and all related logic (some sheets are not completed because of amount of work)
- Refactored `goFuther` method of router (added support for query params)
- Added methods for `AppRoute` to manually add path data or query to location
- Some updates with UIkit
- Refactored `ProfileBloc` to listen for `CurrentSeedService`.

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
