### PR TITLE
refactor: easyL10n use our logger

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -52,6 +52,8 @@ Future<void> bootstrap(
 
       await configureFeatureServices();
 
+      await configureLocalization();
+
       FlutterError.onError = (details) {
         log.severe(details.exceptionAsString(), details, details.stack);
       };
@@ -60,10 +62,6 @@ Future<void> bootstrap(
 
       DefaultAppBar.defaultPopAction = (context) => context.maybePop();
       DefaultAppBar.defaultCanPopAction = (context) => context.canPop();
-
-      WidgetsFlutterBinding.ensureInitialized();
-      // easy_localization claims that this is needed
-      await EasyLocalization.ensureInitialized();
 
       runApp(
         EasyLocalization(

--- a/lib/bootstrap/bootstrap.dart
+++ b/lib/bootstrap/bootstrap.dart
@@ -2,6 +2,7 @@ export 'biometry.dart';
 export 'connection_service.dart';
 export 'encrypted_storage.dart';
 export 'feature_services.dart';
+export 'localization.dart';
 export 'logger.dart';
 export 'migrate_storage.dart';
 export 'navigation_service.dart';

--- a/lib/bootstrap/localization.dart
+++ b/lib/bootstrap/localization.dart
@@ -15,6 +15,7 @@ Future<void> configureLocalization() async {
   void customLogPrinter(
     Object object, {
     LevelMessages? level,
+    // ignore: avoid-unused-parameters
     String? name,
     StackTrace? stackTrace,
   }) {

--- a/lib/bootstrap/localization.dart
+++ b/lib/bootstrap/localization.dart
@@ -1,0 +1,35 @@
+import 'package:app/generated/generated.dart';
+import 'package:easy_logger/easy_logger.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:logging/logging.dart';
+
+/// This is a method that allows configure some feature-related services
+Future<void> configureLocalization() async {
+  final bootstrapLog = Logger('bootstrap')
+    ..finest('EasyLocalization initializating...');
+  final easyLocalizationLog = Logger('easyLocalization');
+
+  WidgetsFlutterBinding.ensureInitialized();
+  // easy_localization claims that this is needed
+  void customLogPrinter(
+    Object object, {
+    LevelMessages? level,
+    String? name,
+    StackTrace? stackTrace,
+  }) {
+    final logLevel = switch (level) {
+      LevelMessages.error => Level.SEVERE,
+      LevelMessages.warning => Level.WARNING,
+      LevelMessages.info => Level.INFO,
+      LevelMessages.debug => Level.FINE,
+      null => Level.FINE,
+    };
+    easyLocalizationLog.log(logLevel, object, null, stackTrace);
+  }
+
+  EasyLocalization.logger.printer = customLogPrinter;
+  await EasyLocalization.ensureInitialized();
+
+  bootstrapLog.finest('EasyLocalization initialized');
+}

--- a/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
+++ b/lib/feature/add_seed/enter_seed_name/view/enter_seed_name_page.dart
@@ -18,6 +18,7 @@ enum EnterSeedNameCommand {
     if (name == null || EnterSeedNameCommand.values.asNameMap()[name] == null) {
       return create;
     }
+
     return EnterSeedNameCommand.values.asNameMap()[name]!;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -330,7 +330,7 @@ packages:
     source: hosted
     version: "3.0.2"
   easy_logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: easy_logger
       sha256: c764a6e024846f33405a2342caf91c62e357c24b02c04dbc712ef232bf30ffb7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   crypto: ^3.0.2
   dotted_border: ^2.0.0+3
   easy_localization: ^3.0.2
+  easy_logger: ^0.0.2
   encrypted_storage:
     path: packages/encrypted_storage
   equatable: ^2.0.5


### PR DESCRIPTION
## Description

EasyLocalization uses EasyLogPrinter (from EasyLogger). This PR transforms direct logs from EasyLogger to our app-wide FancyLogger.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
