### PR TITLE
fix: currency formatter: allow to delete integer while separator is present

### DIFF
--- a/packages/ui_components_lib/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/ui_components_lib/example/ios/Runner.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/packages/ui_components_lib/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/ui_components_lib/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/ui_components_lib/lib/components/input/currency_text_input_formatter.dart
+++ b/packages/ui_components_lib/lib/components/input/currency_text_input_formatter.dart
@@ -49,7 +49,7 @@ class CurrencyTextInputFormatter extends TextInputFormatter {
     final tickerString = includeTicker ? ' ${currency.code}' : '';
 
     final minusSignExp = allowNegative ? '(?<minus>-?)' : '(?<minus>)';
-    const integerExp = '(?<integer>[0-9]+)';
+    const integerExp = '(?<integer>[0-9]*)';
     final separatorExp =
         '(?<separator>$decimalSeparator)'.replaceAll('.', r'\.');
     final decimalExp = '(?<decimal>[0-9]{0,$scale})';

--- a/packages/ui_components_lib/lib/components/input/currency_text_input_validator.dart
+++ b/packages/ui_components_lib/lib/components/input/currency_text_input_validator.dart
@@ -107,6 +107,10 @@ class CurrencyTextInputValidator {
       return error;
     }
 
+    if (separator.isNotEmpty && integer.isEmpty) {
+      return error;
+    }
+
     if (min != null && Fixed.parse(value, scale: _scale) < min!) {
       return minError;
     }


### PR DESCRIPTION
## Description

According to QA feedback we provide a fix for currency formatter: allow to delete integer while separator is present.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
