### PR TITLE
refactor: lifecycle listener method change

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -96,21 +96,27 @@ class AppWrapper extends StatefulWidget {
 }
 
 class _AppWrapperState extends State<AppWrapper> with WidgetsBindingObserver {
+  late final AppLifecycleListener _listener;
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
+
+    _listener = AppLifecycleListener(
+      onStateChange: _onStateChanged,
+    );
+
     appStartSession(setCrashDetected: true);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    _listener.dispose();
+
     super.dispose();
   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
+  void _onStateChanged(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
         startLogSession();


### PR DESCRIPTION
## Description

Use 'new' `AppLifecycleListener` instead of 'old' (and out of fashion) `WidgetsBinding.instance.addObserver` :)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
