### PR TITLE
fix: seed input trash icon placement

### DIFF
--- a/packages/ui_components_lib/lib/components/common/common_card.dart
+++ b/packages/ui_components_lib/lib/components/common/common_card.dart
@@ -130,7 +130,7 @@ class CommonCard extends StatelessWidget {
             mainAxisSize: width == null ? MainAxisSize.min : MainAxisSize.max,
             children: [
               if (subtitle != null) subtitle,
-              Flexible(child: centerTitle ? Center(child: title) : title),
+              Expanded(child: centerTitle ? Center(child: title) : title),
               if (trailingChild != null) trailingChild!,
             ],
           ),


### PR DESCRIPTION
## Description

Fixed seed input trash icon placement by changing CommonCard builder.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
