### PR TITLE
fix: browser tabs top padding

### DIFF
--- a/lib/feature/browser/tabs/tabs_view.dart
+++ b/lib/feature/browser/tabs/tabs_view.dart
@@ -27,7 +27,11 @@ class _TabsViewState extends State<TabsView> {
       children: [
         Expanded(
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: DimensSize.d16),
+            padding: const EdgeInsets.only(
+              left: DimensSize.d16,
+              right: DimensSize.d16,
+              top: DimensSize.d24,
+            ),
             child: GridView.count(
               // ignore: no-magic-number
               crossAxisCount: 2,


### PR DESCRIPTION
## Description

Fix browser tabs top padding according to figma.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
