### PR TITLE
fix: network selecting and editing screens buttons

### DIFF
--- a/lib/feature/network/bottom_sheets/select_network_bottom_sheet.dart
+++ b/lib/feature/network/bottom_sheets/select_network_bottom_sheet.dart
@@ -17,6 +17,8 @@ Future<void> showSelectNetworkSheet({
     expand: true,
     title: LocaleKeys.selectNetwork.tr(),
     body: (_, __) => const SelectNetworkSheet(),
+    padding: EdgeInsets.zero,
+    avoidBottomInsets: false,
   );
 }
 

--- a/lib/feature/network/edit_network/edit_network_view.dart
+++ b/lib/feature/network/edit_network/edit_network_view.dart
@@ -411,7 +411,12 @@ class _EditNetworkViewState extends State<EditNetworkView> {
         ),
       ),
       child: SafeArea(
-        minimum: const EdgeInsets.all(DimensSize.d16),
+        minimum: const EdgeInsets.only(
+          bottom: DimensSize.d32,
+          left: DimensSize.d16,
+          right: DimensSize.d16,
+          top: DimensSize.d16,
+        ),
         child: SeparatedColumn(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/feature/network/view/network_list_view.dart
+++ b/lib/feature/network/view/network_list_view.dart
@@ -101,7 +101,12 @@ class _NetworkListViewState extends State<NetworkListView> {
         ),
       ),
       child: SafeArea(
-        minimum: const EdgeInsets.all(DimensSize.d16),
+        minimum: const EdgeInsets.only(
+          bottom: DimensSize.d32,
+          left: DimensSize.d16,
+          right: DimensSize.d16,
+          top: DimensSize.d16,
+        ),
         child: CommonButton.primary(
           text: widget.buttonText,
           onPressed: widget.onButtonPressed,

--- a/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
+++ b/packages/ui_components_lib/lib/components/displayable/bottom_sheet/common_bottom_sheet.dart
@@ -189,7 +189,9 @@ class CommonBottomSheetWidget extends StatelessWidget {
           ? colors.appBackground
           : colors.backgroundSecondary,
       child: SafeArea(
-        minimum: const EdgeInsets.only(bottom: DimensSize.d24),
+        minimum: avoidBottomInsets
+            ? const EdgeInsets.only(bottom: DimensSize.d24)
+            : EdgeInsets.zero,
         child: Padding(
           padding: avoidBottomInsets
               ? MediaQuery.of(context).viewInsets


### PR DESCRIPTION
## Description

Network selecting and editing screens buttons fix: safearea was affecting background gradient drop.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
