### PR TITLE
fix: position bottomsheet with assets

### DIFF
--- a/lib/feature/wallet/view/wallet_view.dart
+++ b/lib/feature/wallet/view/wallet_view.dart
@@ -3,20 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:nekoton_repository/nekoton_repository.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
-/// Sum of heights of elements on main screen
-final _appbarAccountCardActionsHeight = defaultAppBarHeight +
-    walletActionButtonSize.value +
-    walletAccountCardHeight +
-    walletAccountIndicatorSpace +
-    // multiply by 2 because indicators height is 8 and space between indicator
-    // and button is 8
-    walletAccountsPageIndicatorHeight * 2 +
-    kToolbarHeight +
-    // card margin
-    DimensSize.d12 +
-    // just space below
-    DimensSize.d24;
-
 class WalletView extends StatefulWidget {
   const WalletView({
     required this.controller,
@@ -38,6 +24,9 @@ class WalletView extends StatefulWidget {
 class _WalletViewState extends State<WalletView> {
   final _panelController = PanelController();
 
+  bool _isMountPanel = false;
+  late double _panelHeight = 100;
+
   @override
   void didUpdateWidget(covariant WalletView oldWidget) {
     if (oldWidget.currentAccount != null &&
@@ -55,11 +44,9 @@ class _WalletViewState extends State<WalletView> {
 
   @override
   Widget build(BuildContext context) {
-    final mq = MediaQuery.of(context);
-
     return CommonSlidingPanel(
       maxHeightSizePercent: 1,
-      minHeight: mq.size.height - _appbarAccountCardActionsHeight,
+      minHeight: _panelHeight,
       panelController: _panelController,
       panelBuilder: (context, scrollController) {
         if (widget.currentAccount == null) {
@@ -77,7 +64,22 @@ class _WalletViewState extends State<WalletView> {
         publicKey: widget.publicKey,
         currentAccount: widget.currentAccount,
         controller: widget.controller,
+        onMount: _onMount,
       ),
     );
+  }
+
+  void _onMount(double bottom) {
+    if (_isMountPanel || bottom == 0) {
+      return;
+    }
+
+    _isMountPanel = true;
+
+    final mq = MediaQuery.of(context);
+
+    setState(() {
+      _panelHeight = mq.size.height - (bottom + DimensSize.d48);
+    });
   }
 }

--- a/lib/feature/wallet/widgets/wallet_accounts_body.dart
+++ b/lib/feature/wallet/widgets/wallet_accounts_body.dart
@@ -2,6 +2,7 @@ import 'package:app/feature/wallet/wallet.dart';
 import 'package:app/feature/widgets/change_notifier_listener.dart';
 import 'package:flutter/material.dart';
 import 'package:nekoton_repository/nekoton_repository.dart';
+import 'package:render_metrics/render_metrics.dart';
 import 'package:ui_components_lib/ui_components_lib.dart';
 
 const walletAccountCardHeight = DimensSize.d220;
@@ -16,6 +17,7 @@ class WalletAccountsBody extends StatefulWidget {
     required this.currentAccount,
     required this.controller,
     required this.publicKey,
+    required this.onMount,
     super.key,
   });
 
@@ -23,6 +25,7 @@ class WalletAccountsBody extends StatefulWidget {
   final PublicKey publicKey;
   final KeyAccount? currentAccount;
   final PageController controller;
+  final ValueChanged<double> onMount;
 
   @override
   State<WalletAccountsBody> createState() => _WalletAccountsBodyState();
@@ -80,12 +83,25 @@ class _WalletAccountsBodyState extends State<WalletAccountsBody> {
             mainAxisSize: MainAxisSize.min,
             children: [
               _pageIndicators(list.length + 1),
-              WalletAccountActions(currentAccount: widget.currentAccount),
+              RenderMetricsObject(
+                id: '_id',
+                onMount: _onUpdate,
+                onUpdate: _onUpdate,
+                child: WalletAccountActions(
+                  currentAccount: widget.currentAccount,
+                ),
+              ),
             ],
           ),
         ),
       ],
     );
+  }
+
+  void _onUpdate(_, RenderMetricsBox rb) {
+    Future.delayed(const Duration(milliseconds: 100), () {
+      widget.onMount(rb.data.bottomCenter.y);
+    });
   }
 
   Widget _pageIndicators(int count) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1596,6 +1596,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
+  render_metrics:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: optional-render-manager
+      resolved-ref: "1e2440c00e65b4a70d94be5b4d41f47a940fdd94"
+      url: "https://github.com/knightsforce/flutter-render-metrics"
+    source: git
+    version: "2.0.4"
   rxdart:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,12 @@ dependencies:
   url_launcher: ^6.2.6
   uuid: ^3.0.7
   visibility_detector: ^0.4.0+2
+  render_metrics:
+#    Temporarily. Before the adoption of the PR
+#    https://github:com/surfstudio/flutter-render-metrics/pull/27:
+    git:
+      url: https://github.com/knightsforce/flutter-render-metrics
+      ref: optional-render-manager
 
 dev_dependencies:
   bloc_test: ^9.1.7


### PR DESCRIPTION
## Description

Bottomsheet position with assets on the wallet screen using RenderMetrics.

Pixel 7 Emulator.
![telegram-cloud-photo-size-2-5462985284691030465-y](https://github.com/broxus/ever_wallet_flutter_new/assets/7579063/85ebdf51-dd34-41b3-b54c-cb4c0d3df53e)

Galaxy S21 Ulra.
![telegram-cloud-photo-size-2-5463291949650927936-y](https://github.com/broxus/ever_wallet_flutter_new/assets/7579063/1ea6150b-0554-429f-a4e1-151865a8f2ac)

iPhone 14 Pro Emulator.
<img width="419" alt="image" src="https://github.com/broxus/ever_wallet_flutter_new/assets/7579063/71acaee0-4c16-4aea-943f-fc7a7b9d7f90">

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
