### PR TITLE
fix: Removed shading from DefaultAppBar when scrolling

### DIFF
--- a/packages/ui_components_lib/lib/components/common/default_app_bar.dart
+++ b/packages/ui_components_lib/lib/components/common/default_app_bar.dart
@@ -162,8 +162,10 @@ class DefaultAppBar extends StatelessWidget implements PreferredSizeWidget {
       padding: const EdgeInsets.symmetric(horizontal: DimensSize.d16),
       child: AppBar(
         backgroundColor: backgroundColor ?? Colors.transparent,
+        surfaceTintColor: Colors.transparent,
         toolbarHeight: preferredSize.height,
         elevation: 0,
+        scrolledUnderElevation: 0,
         titleSpacing: DimensSize.d8,
         centerTitle: centerTitle,
         leadingWidth: leadingWidth,


### PR DESCRIPTION
## Description

Removed shading from DefaultAppBar when scrolling.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
