### PR TITLE
fix(EWM_TECH): Fixed bug with recursive update showing

### DIFF
--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -92,7 +92,14 @@ class CompassRouter {
   GoRouter get router => _router;
 
   /// Returns the current [Uri] of the navigation stack.
-  Uri get currentUri => _router.routerDelegate.currentConfiguration.uri;
+  Uri get currentUri {
+    // Manual check needed because state call currentConfiguration.last
+    // that could throw BadStateException
+    if (_router.routerDelegate.currentConfiguration.lastOrNull == null) {
+      return Uri();
+    }
+    return _router.state.uri;
+  }
 
   /// Returns the current active routes in the navigation stack.
   ///

--- a/lib/feature/update_version/guard.dart
+++ b/lib/feature/update_version/guard.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'package:app/app/router/compass/compass.dart';
 import 'package:app/app/router/router.dart';
+import 'package:app/bootstrap/sentry.dart';
 import 'package:app/feature/update_version/route.dart';
 import 'package:app/feature/update_version/update_version.dart';
 import 'package:app/feature/wallet/route.dart';
+import 'package:app/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
 import 'package:logging/logging.dart';
@@ -18,12 +20,15 @@ class UpdateVersionGuard extends CompassGuard {
     this._updateService,
   ) : super(priority: priorityLow);
 
+  static const _minimumDelaySeconds = 60;
+
   final UpdateService _updateService;
   final _log = Logger('UpdateVersionGuard');
 
   StreamSubscription<(UpdateRequest?, CompassBaseGoRoute?)>?
       _updateVersionSubscription;
   CompassRouter? _router;
+  int? _warningLastTimeSecs;
 
   @override
   void attachToRouter(CompassRouter router) {
@@ -52,18 +57,49 @@ class UpdateVersionGuard extends CompassGuard {
     return null;
   }
 
-  void _onUpdateRequests(
+  Future<void> _onUpdateRequests(
     (UpdateRequest?, CompassBaseGoRoute?) requestRoute,
-  ) {
+  ) async {
     final (request, currentRoute) = requestRoute;
     if (request == null) return;
     if (currentRoute is! WalletRoute) return;
 
     _log.info('Open update version screen $currentRoute, $request');
 
-    _router?.compassPush(
+    if (!_checkMinimumDelayBetweenShow()) {
+      return;
+    }
+
+    await _router?.compassPush(
       const UpdateVersionRouteData(),
       isContinue: false,
     );
+  }
+
+  // Normally this check isn’t required, but if a bug causes
+  // `UpdateVersionRouteData()` to fire twice, it can lead to a jarring user
+  // experience. This method enforces a minimum delay between shows.
+  bool _checkMinimumDelayBetweenShow() {
+    final nowSecs = NtpTime.now().millisecondsSinceEpoch ~/ 1000;
+
+    final warningLastTimeSecs = _warningLastTimeSecs;
+    if (warningLastTimeSecs != null) {
+      final elapsedSecs = nowSecs - warningLastTimeSecs;
+
+      if (elapsedSecs < _minimumDelaySeconds) {
+        _log.info(
+          'Not enough time between request show: '
+          '$elapsedSecs < $_minimumDelaySeconds',
+        );
+        SentryWorker.instance.captureException(
+          StateError('Update screen tries show twice'),
+        );
+        return false;
+      }
+    }
+
+    _warningLastTimeSecs = nowSecs;
+
+    return true;
   }
 }


### PR DESCRIPTION
## Description

Fixed bug, when `currentRoutesStream` notify listeners with same route after compassPush (it will make recursive update bug).

Now `currentRoutesStream` work with `currentUri` which return actual routes and don't throw BadState.

Also add protection in `UpdateGuard` from duplication of update request

copilot:all

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore